### PR TITLE
Fix missing attribute

### DIFF
--- a/2002_Wo-waere-ich-heute.xml
+++ b/2002_Wo-waere-ich-heute.xml
@@ -15,7 +15,7 @@
                <licence target="https://creativecommons.org/licenses/by/null/">CC0</licence>
             </availability>
             <date when="2020-05-29T22:29:46.872-02:00"/>
-            <idno>https://raw.githubusercontent.com/arthur-schnitzler/schnitzler-cmif/main/2002_Wo-waere-ich-heute.xml</idno>
+            <idno type="url">https://raw.githubusercontent.com/arthur-schnitzler/schnitzler-cmif/main/2002_Wo-waere-ich-heute.xml</idno>
          </publicationStmt>
          <sourceDesc>
             <bibl type="print" xml:id="a83cb8bd-8952-4ade-a8c0-0f6f4ec2733b">Peter Michael


### PR DESCRIPTION
in publicationStmt/idno; preventing CMIF file from being harvested by correspSearch :-) 